### PR TITLE
Fixed deprecated grid syntax & Fix for bundle size in dev environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint": "^9.25.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
+        "eslint-plugin-unused-imports": "^4.1.4",
         "globals": "^16.0.0",
         "vite": "^6.3.5"
       }
@@ -2134,6 +2135,22 @@
       "dev": true,
       "peerDependencies": {
         "eslint": ">=8.40"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.1.4.tgz",
+      "integrity": "sha512-YptD6IzQjDardkl0POxnnRBhU1OEePMV0nd6siHaRBbd+lyh6NAhFEobiznKU7kTsSsDeSD62Pe7kAM1b7dAZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^8.0.0-0 || ^7.0.0 || ^6.0.0 || ^5.0.0",
+        "eslint": "^9.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
+    "eslint-plugin-unused-imports": "^4.1.4",
     "globals": "^16.0.0",
     "vite": "^6.3.5"
   }

--- a/src/components/BigBoard.jsx
+++ b/src/components/BigBoard.jsx
@@ -1,7 +1,11 @@
 import { useState, useEffect } from 'react';
 import { loadPlayerData } from '../utils/dataProcessor';
 import PlayerCard from './PlayerCard';
-import { Container, Typography, Grid, CircularProgress, Box } from '@mui/material';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Grid from '@mui/material/Grid';
+import CircularProgress from '@mui/material/CircularProgress';
+import Box from '@mui/material/Box';
 import { Link } from 'react-router-dom'; // Import Link
 
 const BigBoard = () => {

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,5 +1,8 @@
 
-import { AppBar, Toolbar, Typography, Button, Box } from '@mui/material';
+import AppBar from '@mui/material/AppBar';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import Toolbar from '@mui/material/Toolbar';
 import { Link as RouterLink } from 'react-router-dom'; // Alias for clarity
 
 const Navbar = () => {

--- a/src/components/PlayerProfile.jsx
+++ b/src/components/PlayerProfile.jsx
@@ -2,11 +2,27 @@ import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 import { loadPlayerData } from '../utils/dataProcessor';
 import ScoutingReportForm from './ScoutingReportForm'; // Import the form
-import { 
-    Container, Typography, Grid, CardMedia, List, ListItem, ListItemText, 
-    Paper, Box, CircularProgress, Avatar, Select, MenuItem, FormControl, InputLabel,
-    Table, TableBody, TableCell, TableContainer, TableHead, TableRow
-} from '@mui/material';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Grid from '@mui/material/Grid';
+import CardMedia from '@mui/material/CardMedia';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
+import Paper from '@mui/material/Paper';
+import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
+import Avatar from '@mui/material/Avatar';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import Table from '@mui/material/Table';
+import TableBody from '@mui/material/TableBody';
+import TableCell from '@mui/material/TableCell';
+import TableContainer from '@mui/material/TableContainer';
+import TableHead from '@mui/material/TableHead';
+import TableRow from '@mui/material/TableRow';
 import { format } from 'date-fns';
 
 
@@ -147,7 +163,7 @@ if (!selectedPlayer) {
     <Container sx={{ mt: 3, mb: 3 }}>
       <Grid container spacing={3}>
         {/* Bio Section */}
-        <Grid item xs={12} md={4}>
+        <Grid>
           <Paper elevation={3} sx={{ p: 2, display: 'flex', flexDirection: 'column', height: '100%' }}>
             {playerData.photoUrl ? (
               <CardMedia component="img" image={playerData.photoUrl} alt={`${playerData.firstName} ${playerData.lastName}`} sx={{ width: '100%', mb: 2, borderRadius: '4px' }} onError={(e) => { e.target.src = placeholderImageUrl; }} />
@@ -164,20 +180,20 @@ if (!selectedPlayer) {
           </Paper>
         </Grid>
 
-        <Grid item xs={12} md={8}>
+        <Grid>
           {/* Measurements Section */}
           {playerData.measurements && Object.keys(playerData.measurements).length > 1 && (
             <Paper elevation={3} sx={{ p: 2, mb: 3 }}>
               <Typography variant="h5" gutterBottom>Measurements</Typography>
               <Grid container spacing={1}>
-                <Grid item xs={12} sm={6} md={4}><Typography>Height (No Shoes): {getHeightInFeetInches(playerData.measurements.heightNoShoes)}</Typography></Grid>
-                <Grid item xs={12} sm={6} md={4}><Typography>Wingspan: {getHeightInFeetInches(playerData.measurements.wingspan)}</Typography></Grid>
-                <Grid item xs={12} sm={6} md={4}><Typography>Standing Reach: {getHeightInFeetInches(playerData.measurements.reach)}</Typography></Grid>
-                <Grid item xs={12} sm={6} md={4}><Typography>Max Vertical: {playerData.measurements.maxVertical != null ? `${playerData.measurements.maxVertical}"` : 'N/A'}</Typography></Grid>
-                <Grid item xs={12} sm={6} md={4}><Typography>Weight: {playerData.measurements.weight != null ? `${playerData.measurements.weight} lbs` : 'N/A'}</Typography></Grid>
-                <Grid item xs={12} sm={6} md={4}><Typography>Body Fat: {playerData.measurements.bodyFat != null ? `${playerData.measurements.bodyFat}%` : 'N/A'}</Typography></Grid>
-                <Grid item xs={12} sm={6} md={4}><Typography>Hand Length: {playerData.measurements.handLength != null ? `${playerData.measurements.handLength}"` : 'N/A'}</Typography></Grid>
-                <Grid item xs={12} sm={6} md={4}><Typography>Hand Width: {playerData.measurements.handWidth != null ? `${playerData.measurements.handWidth}"` : 'N/A'}</Typography></Grid>
+                <Grid size={{xs:12, sm:6, md:4}} ><Typography>Wingspan: {getHeightInFeetInches(playerData.measurements.wingspan)}</Typography></Grid>
+                <Grid size={{xs:12, sm:6, md:4}} ><Typography>Height (No Shoes): {getHeightInFeetInches(playerData.measurements.heightNoShoes)}</Typography></Grid>
+                <Grid size={{xs:12, sm:6, md:4}} ><Typography>Standing Reach: {getHeightInFeetInches(playerData.measurements.reach)}</Typography></Grid>
+                <Grid size={{xs:12, sm:6, md:4}} ><Typography>Max Vertical: {playerData.measurements.maxVertical != null ? `${playerData.measurements.maxVertical}"` : 'N/A'}</Typography></Grid>
+                <Grid size={{xs:12, sm:6, md:4}} ><Typography>Weight: {playerData.measurements.weight != null ? `${playerData.measurements.weight} lbs` : 'N/A'}</Typography></Grid>
+                <Grid size={{xs:12, sm:6, md:4}} ><Typography>Body Fat: {playerData.measurements.bodyFat != null ? `${playerData.measurements.bodyFat}%` : 'N/A'}</Typography></Grid>
+                <Grid size={{xs:12, sm:6, md:4}} ><Typography>Hand Length: {playerData.measurements.handLength != null ? `${playerData.measurements.handLength}"` : 'N/A'}</Typography></Grid>
+                <Grid size={{xs:12, sm:6, md:4}} ><Typography>Hand Width: {playerData.measurements.handWidth != null ? `${playerData.measurements.handWidth}"` : 'N/A'}</Typography></Grid>
               </Grid>
             </Paper>
           )}


### PR DESCRIPTION
+ Fixed barrel imports for reduced bundle size  
+ Reformatted Grid component props due to deprecated syntax

### Old:
<img width="623" alt="image" src="https://github.com/user-attachments/assets/ff8ce817-4c12-4c04-bad0-c59bc466a4e3" />


### New:
<img width="643" alt="image" src="https://github.com/user-attachments/assets/27e87350-977d-4925-9149-0cc4c0002b3f" />


Measurements section has better formatting
Closes issue #15 